### PR TITLE
Use empty() to test sequence

### DIFF
--- a/f/foldl.xsl
+++ b/f/foldl.xsl
@@ -9,7 +9,7 @@
       <xsl:param name="pList" select="/.."/>
 
       <xsl:choose>
-         <xsl:when test="not($pList)">
+         <xsl:when test="empty($pList)">
             <xsl:copy-of select="$pA0"/>
          </xsl:when>
          <xsl:otherwise>


### PR DESCRIPTION
In XPath 2.0, due to changes in the conversion-to-boolean rules, not() is no longer a reliable way to check whether a sequence is empty. Rather, the new function empty() is a better way (as being used currently in func-foldl.xsl, in this repository).