### PR TITLE
Use empty() to test sequence

### DIFF
--- a/f/foldr.xsl
+++ b/f/foldr.xsl
@@ -10,7 +10,7 @@
       <xsl:param name="pList" select="/.."/>
       
       <xsl:choose>
-         <xsl:when test="not($pList)">
+         <xsl:when test="empty($pList)">
             <xsl:copy-of select="$pA0"/>
          </xsl:when>
          <xsl:otherwise>


### PR DESCRIPTION
In XPath 2.0, due to changes in the conversion-to-boolean rules, not() is no longer a reliable way to check whether a sequence is empty. Rather, the new function empty() is a better way (as being used currently in func-foldr.xsl, in this repository).